### PR TITLE
fix(server): Send room list on new connection (fixes #26)

### DIFF
--- a/project_desc/repo/add_to_repository.txt
+++ b/project_desc/repo/add_to_repository.txt
@@ -93,3 +93,29 @@ classname: useGameStore (Zustand Hook/Store)
 function name: startGame (Action)
 short description: Uncommented the call to `socketService.startGame` to ensure the 'startGame' event is emitted to the server when the action is called.
 input / output: Takes no input. Calls `socketService.startGame` with `currentRoom.id`.
+---
+file name: server/src/server.ts
+function name: (event handler) 'connection'
+short description: Modified to emit the 'roomListUpdated' event with the current room summaries to the newly connected client. This ensures the client receives the initial room list upon connecting.
+input / output: Emits 'roomListUpdated' event with `RoomSummary[]` payload to the connecting socket.
+
+---
+file name: src/types/socket.ts
+classname: ServerToClientEvents (Interface)
+property name: roomListUpdated
+short description: Renamed the 'availableRoomsUpdated' event to 'roomListUpdated' for consistency with the server-side event name.
+input / output: Event name changed from 'availableRoomsUpdated' to 'roomListUpdated'. Payload remains `RoomSummary[]`.
+
+---
+file name: src/services/socketService.ts
+classname: SocketService
+function name: onRoomListUpdated
+short description: Renamed the 'onAvailableRoomsUpdated' method to 'onRoomListUpdated' and updated the registered event listener to listen for 'roomListUpdated' instead of 'availableRoomsUpdated'.
+input / output: Method name changed. Listens for 'roomListUpdated' event.
+
+---
+file name: src/stores/gameStore.ts
+classname: useGameStore (Zustand Hook/Store)
+function name: connect (Action)
+short description: Modified the event listener registration within the connect action to use `socketService.onRoomListUpdated` instead of `socketService.onAvailableRoomsUpdated`.
+input / output: Calls `onRoomListUpdated` to register the listener for room list updates.

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -58,6 +58,9 @@ setInterval(() => {
 io.on('connection', (socket: Socket) => {
   logger.info(`New connection: ${socket.id}`);
 
+  // 新規接続時に現在のルームリストを送信
+  socket.emit('roomListUpdated', roomManager.getRoomSummaries());
+
   socket.on('register', ({ name }: { name: string }) => {
     try {
       const playerId = socket.id;

--- a/src/services/socketService.ts
+++ b/src/services/socketService.ts
@@ -182,8 +182,8 @@ private emit<Event extends keyof ClientToServerEvents>(
     this.registerEventListener('roomUpdated', callback);
   }
 
-  public onAvailableRoomsUpdated(callback: ServerToClientEvents['availableRoomsUpdated']): void { // 型を更新 (RoomSummary[])
-    this.registerEventListener('availableRoomsUpdated', callback);
+  public onRoomListUpdated(callback: ServerToClientEvents['roomListUpdated']): void { // メソッド名とイベント名を修正
+    this.registerEventListener('roomListUpdated', callback);
   }
 
   public onError(callback: ServerToClientEvents['error']): void {

--- a/src/stores/gameStore.ts
+++ b/src/stores/gameStore.ts
@@ -142,7 +142,7 @@ const useGameStore = create<GameStore>((set, get) => ({
         }
       });
       // ルームリスト更新リスナーを追加
-      socketService.onAvailableRoomsUpdated((rooms) => {
+      socketService.onRoomListUpdated((rooms) => { // メソッド名を修正
         set({ availableRooms: rooms });
       });
       // --- ここまで ---

--- a/src/types/socket.ts
+++ b/src/types/socket.ts
@@ -10,7 +10,7 @@ export interface ServerToClientEvents {
   roomJoined: (room: Room) => void;
   roomLeft: (payload: { roomId: string; updatedRoom: Room }) => void; // サーバーの実装に合わせる
   roomUpdated: (room: Room) => void;
-  availableRoomsUpdated: (rooms: RoomSummary[]) => void; // ルームリスト更新イベント (RoomSummaryを使用)
+  roomListUpdated: (rooms: RoomSummary[]) => void; // ルームリスト更新イベント (RoomSummaryを使用) - イベント名を修正
   error: (error: { message: string }) => void;
   // --- ゲームイベントを追加 ---
   gameStarted: (initialGameState: MultiplayerGameState) => void;


### PR DESCRIPTION
Fixes #26 by sending the current room list to newly connected clients via the 'roomListUpdated' event. Also updates client-side event listeners to use the correct event name.