### PR TITLE
[Backend] feat: include boardPatternIds in gameStarted event (issue #43)

### DIFF
--- a/project_desc/repo/add_to_repository.txt
+++ b/project_desc/repo/add_to_repository.txt
@@ -55,3 +55,20 @@ File: server/src/server.ts
 Function: (Socket.IO 'createRoom' event handler)
 Short description: Added an event listener for the 'gameStateUpdated' event emitted by the GameManager instance. When the event is received, the updated game state is broadcasted to all clients in the corresponding room using the 'gameStateUpdated' socket event.
 Input / Output: N/A (Listens for internal events and emits socket events)
+
+File: server/src/types/game.ts
+Interface: MultiplayerGameState
+Short description: Added the 'boardPatternIds: string[]' property to include the IDs of the board patterns used in the game.
+Input / Output: N/A (Type definition)
+
+File: server/src/services/gameManager.ts
+Class: GameManager
+Function: constructor
+Short description: Modified to accept 'boardPatternIds: string[]' as an argument and store it. Included 'boardPatternIds' in the initialized game state.
+Input / Output: Input: players: Player[], boardPatternIds: string[], rules: GameRules / Output: void
+
+File: server/src/services/roomManager.ts
+Class: RoomManager
+Function: createRoom
+Short description: Modified to pass a fixed array of board pattern IDs (placeholder: ['A1', 'B2', 'C3', 'D4']) to the GameManager constructor. Added a TODO comment to implement a server-side BoardLoader in the future.
+Input / Output: Input: hostPlayer: Player, options: RoomOptions / Output: Room

--- a/server/src/services/gameManager.ts
+++ b/server/src/services/gameManager.ts
@@ -15,12 +15,14 @@ export class GameManager extends EventEmitter { // EventEmitter を継承
   private rules: GameRules;
   private players: Player[];
   private timerInterval?: NodeJS.Timeout;
+  private boardPatternIds: string[]; // Added: Store the board pattern IDs
   // private penaltyApplied: Set<string>; // No longer needed with the new rule
 
-  constructor(players: Player[], rules: GameRules = DEFAULT_GAME_RULES) {
+  constructor(players: Player[], boardPatternIds: string[], rules: GameRules = DEFAULT_GAME_RULES) {
     super(); // EventEmitter のコンストラクタを呼び出す
     this.rules = rules;
     this.players = players;
+    this.boardPatternIds = boardPatternIds; // Store the board pattern IDs
     this.gameState = this.initializeGameState();
     // this.penaltyApplied = new Set(); // No longer needed
   }
@@ -44,7 +46,8 @@ export class GameManager extends EventEmitter { // EventEmitter を継承
       timer: 0,
       timerStartedAt: Date.now(), // Initialize with a value
       robotPositions: {} as Record<RobotColor, Position>, // Cast to satisfy type checker initially
-      moveHistory: []
+      moveHistory: [],
+      boardPatternIds: this.boardPatternIds // Add board pattern IDs to the initial state
     };
   }
 

--- a/server/src/services/roomManager.ts
+++ b/server/src/services/roomManager.ts
@@ -17,7 +17,9 @@ export class RoomManager {
     hostPlayer.isHost = true;
     hostPlayer.roomId = roomId; // roomIdも設定
     // GameManager を先にインスタンス化
-    const gameManager = new GameManager([hostPlayer], DEFAULT_GAME_RULES);
+    // TODO: Implement server-side BoardLoader to get dynamic patterns
+    const boardPatternIds = ['A1', 'B2', 'C3', 'D4']; // Placeholder: Use fixed patterns for now
+    const gameManager = new GameManager([hostPlayer], boardPatternIds, DEFAULT_GAME_RULES);
     const room: Room = {
       id: roomId,
       name: options.name,

--- a/server/src/types/game.ts
+++ b/server/src/types/game.ts
@@ -55,6 +55,7 @@ export interface MultiplayerGameState {
     timestamp: number;
   }[];
   rankings?: { playerId: string; score: number; rank: number }[]; // Added for final rankings
+  boardPatternIds: string[]; // Added: IDs of the board patterns used (e.g., ['A1', 'B2', 'C3', 'D4'])
 }
 
 export interface GameRules {


### PR DESCRIPTION
Adds the 'boardPatternIds' array to the MultiplayerGameState and ensures it's included in the 'gameStarted' event payload. This provides the frontend with the necessary static board structure information. Fixes #43