### PR TITLE
fix: Handle playerListUpdated event and ensure player list visibility (issue #77)

### DIFF
--- a/project_desc/repo/add_to_repository.txt
+++ b/project_desc/repo/add_to_repository.txt
@@ -1,95 +1,119 @@
 - file name: src/components/PlayerNameInput.tsx
-   - classname: N/A (Function Component)
-   - function name: PlayerNameInput
-   - short description: Component for inputting and registering a player name. Handles input, loading state, and basic error display. Uses useGameStore for registration.
-   - input / output: Props: `onRegistered?: () => void` / JSX
+    - classname: N/A (Function Component)
+    - function name: PlayerNameInput
+    - short description: Component for inputting and registering a player name. Handles input, loading state, and basic error display. Uses useGameStore for registration.
+    - input / output: Props: `onRegistered?: () => void` / JSX
+    
+    - file name: src/pages/CreateRoomPage.tsx
+    - classname: N/A (Function Component)
+    - function name: CreateRoomPage
+    - short description: Page for creating a game room. Modified to display PlayerNameInput component if the player is not yet registered, before showing the room creation form. Removed automatic player registration logic.
+    - input / output: None / JSX
+    
+    - file name: src/pages/JoinRoomPage.tsx
+    - classname: N/A (Function Component)
+    - function name: JoinRoomPage
+    - short description: Page for joining an existing game room. Modified to display PlayerNameInput component if the player is not yet registered, before showing the room list. Removed automatic player registration logic.
+    - input / output: None / JSX
+    
+    - file name: server/src/types/game.ts
+    - classname: N/A (Interface)
+    - function name: MultiplayerGameState
+    - short description: Added `playersInfo: Record<string, { name: string }>` property to include player names in the game state sent to clients.
+    - input / output: N/A
+    
+    - file name: server/src/services/gameManager.ts
+    - classname: GameManager
+    - function name: initializeGameState, startGame
+    - short description: Modified to populate the new `playersInfo` property in the `MultiplayerGameState`.
+    - input / output: N/A
+    
+    - file name: src/services/socketService.ts
+    - classname: SocketService
+    - function name: registerPlayer
+    - short description: Changed the payload sent for the 'register' event from a string `name` to an object `{ name }` to match server expectations.
+    - input / output: `name: string` / `void`
+    
+    - file name: src/types/socket.ts
+    - classname: N/A (Interface)
+    - function name: ClientToServerEvents
+    - short description: Updated the type definition for the 'register' event to expect a payload of type `{ name: string }` instead of just `string`.
+    - input / output: N/A
    
-   - file name: src/pages/CreateRoomPage.tsx
-   - classname: N/A (Function Component)
-   - function name: CreateRoomPage
-   - short description: Page for creating a game room. Modified to display PlayerNameInput component if the player is not yet registered, before showing the room creation form. Removed automatic player registration logic.
-   - input / output: None / JSX
-   
-   - file name: src/pages/JoinRoomPage.tsx
-   - classname: N/A (Function Component)
-   - function name: JoinRoomPage
-   - short description: Page for joining an existing game room. Modified to display PlayerNameInput component if the player is not yet registered, before showing the room list. Removed automatic player registration logic.
-   - input / output: None / JSX
-   
-   - file name: server/src/types/game.ts
-   - classname: N/A (Interface)
-   - function name: MultiplayerGameState
-   - short description: Added `playersInfo: Record<string, { name: string }>` property to include player names in the game state sent to clients.
-   - input / output: N/A
-   
-   - file name: server/src/services/gameManager.ts
-   - classname: GameManager
-   - function name: initializeGameState, startGame
-   - short description: Modified to populate the new `playersInfo` property in the `MultiplayerGameState`.
-   - input / output: N/A
-   
-   - file name: src/services/socketService.ts
-   - classname: SocketService
-   - function name: registerPlayer
-   - short description: Changed the payload sent for the 'register' event from a string `name` to an object `{ name }` to match server expectations.
-   - input / output: `name: string` / `void`
-   
-   - file name: src/types/socket.ts
-   - classname: N/A (Interface)
-   - function name: ClientToServerEvents
-   - short description: Updated the type definition for the 'register' event to expect a payload of type `{ name: string }` instead of just `string`.
-   - input / output: N/A
+    - file name: src/pages/GamePage.tsx
+    - classname: N/A (Function Component)
+    - function name: GamePage, MovingRobotInfo (interface)
+    - short description: Modified robot animation logic to follow the calculated path smoothly segment by segment using requestAnimationFrame and linear interpolation. Stored the calculated path in the component's state (`movingRobots`) when a move is initiated. Adjusted animation timing based on segment duration. Refactored useEffect hooks related to game state changes and animation triggering.
+    - input / output: N/A
   
-   - file name: src/pages/GamePage.tsx
-   - classname: N/A (Function Component)
-   - function name: GamePage, MovingRobotInfo (interface)
-   - short description: Modified robot animation logic to follow the calculated path smoothly segment by segment using requestAnimationFrame and linear interpolation. Stored the calculated path in the component's state (`movingRobots`) when a move is initiated. Adjusted animation timing based on segment duration. Refactored useEffect hooks related to game state changes and animation triggering.
-   - input / output: N/A
+   - file name: server/src/services/gameManager.ts
+    - classname: GameManager
+    - function name: proceedToNextRound, endGame
+    - short description: Modified to reset robot positions to their initial state when proceeding to the next round or ending the game.
+    - input / output: N/A
+  
+  - file name: server/src/services/gameManager.ts
+    - classname: GameManager
+    - function name: successCurrentSolution, failCurrentSolution, handleDrawCard, proceedToNextRound
+    - short description: Modified game flow to transition to WAITING phase after a solution attempt (success or failure) instead of automatically proceeding to the next round. The next round now starts explicitly when a player requests to draw a card in the WAITING phase.
+    - input / output: N/A
+  
+  - file name: src/components/GameInfo.tsx
+    - classname: N/A (Function Component)
+    - function name: GameInfo
+    - short description: Removed the duplicate "draw card" button. This button is now handled solely within the GamePage's control area.
+    - input / output: N/A
+  
+  - file name: src/pages/GamePage.tsx
+    - classname: N/A (Function Component)
+    - function name: GamePage
+    - short description: Changed the style of the "draw card" button in the control area to use the primary color (blue) when it is clickable (active).
+    - input / output: N/A
+  
+  - file name: src/components/DeclarationCard.tsx
+    - classname: N/A (Function Component)
+    - function name: DeclarationCardList
+    - short description: Modified the arrow buttons to allow scrolling even after a declaration is made. Removed the `isDisabled` check from the arrow button's `disabled` attribute and CSS classes to ensure they remain functional and visually appropriate regardless of the overall list's disabled state.
+    - input / output: N/A
  
   - file name: server/src/services/gameManager.ts
-   - classname: GameManager
-   - function name: proceedToNextRound, endGame
-   - short description: Modified to reset robot positions to their initial state when proceeding to the next round or ending the game.
-   - input / output: N/A
+    - classname: GameManager
+    - function name: constructor, initializeGameState, generateRandomRobotPositions, isTargetPosition, startGame, successCurrentSolution, failCurrentSolution, proceedToNextRound, endGame
+    - short description: (Issue #79) Changed robot initial positions to be generated randomly once at game start, avoiding center area, other robots, and target positions. Reset positions to these initial values during phase/round transitions.
+    - input / output: N/A
  
- - file name: server/src/services/gameManager.ts
-   - classname: GameManager
-   - function name: successCurrentSolution, failCurrentSolution, handleDrawCard, proceedToNextRound
-   - short description: Modified game flow to transition to WAITING phase after a solution attempt (success or failure) instead of automatically proceeding to the next round. The next round now starts explicitly when a player requests to draw a card in the WAITING phase.
-   - input / output: N/A
+  - file name: server/src/services/gameManager.ts
+    - classname: GameManager
+    - function name: failCurrentSolution
+    - short description: (Issue #78) Fixed an issue where robot positions were not reset to initial state when the turn passed to the next player after a failed solution attempt.
+    - input / output: N/A
  
- - file name: src/components/GameInfo.tsx
-   - classname: N/A (Function Component)
-   - function name: GameInfo
-   - short description: Removed the duplicate "draw card" button. This button is now handled solely within the GamePage's control area.
-   - input / output: N/A
- 
- - file name: src/pages/GamePage.tsx
-   - classname: N/A (Function Component)
-   - function name: GamePage
-   - short description: Changed the style of the "draw card" button in the control area to use the primary color (blue) when it is clickable (active).
-   - input / output: N/A
- 
- - file name: src/components/DeclarationCard.tsx
-   - classname: N/A (Function Component)
-   - function name: DeclarationCardList
-   - short description: Modified the arrow buttons to allow scrolling even after a declaration is made. Removed the `isDisabled` check from the arrow button's `disabled` attribute and CSS classes to ensure they remain functional and visually appropriate regardless of the overall list's disabled state.
-   - input / output: N/A
+  - file name: server/src/server.ts
+    - classname: N/A
+    - function name: Event handlers for 'joinRoom', 'leaveRoom', 'disconnect'
+    - short description: (Issue #77) Refactored player list updates. Instead of sending individual events ('playerJoined', 'playerLeft', 'playerDisconnected'), now sends the complete updated player list via a 'playerListUpdated' event to all clients in the room whenever the list changes.
+    - input / output: N/A
 
- - file name: server/src/services/gameManager.ts
-   - classname: GameManager
-   - function name: constructor, initializeGameState, generateRandomRobotPositions, isTargetPosition, startGame, successCurrentSolution, failCurrentSolution, proceedToNextRound, endGame
-   - short description: (Issue #79) Changed robot initial positions to be generated randomly once at game start, avoiding center area, other robots, and target positions. Reset positions to these initial values during phase/round transitions.
-   - input / output: N/A
+- file name: src/types/socket.ts
+  - classname: N/A (Interface)
+  - function name: ServerToClientEvents
+  - short description: (Issue #77) Updated `playerListUpdated` event payload type to `{ players: Player[] }` to match the actual server data format.
+  - input / output: N/A
 
- - file name: server/src/services/gameManager.ts
-   - classname: GameManager
-   - function name: failCurrentSolution
-   - short description: (Issue #78) Fixed an issue where robot positions were not reset to initial state when the turn passed to the next player after a failed solution attempt.
-   - input / output: N/A
+- file name: src/services/socketService.ts
+  - classname: SocketService
+  - function name: onPlayerListUpdated
+  - short description: (Issue #77) Updated the callback type for `onPlayerListUpdated` method to accept `{ players: Player[] }`.
+  - input / output: `callback: (payload: { players: Player[] }) => void` / `void`
 
- - file name: server/src/server.ts
-   - classname: N/A
-   - function name: Event handlers for 'joinRoom', 'leaveRoom', 'disconnect'
-   - short description: (Issue #77) Refactored player list updates. Instead of sending individual events ('playerJoined', 'playerLeft', 'playerDisconnected'), now sends the complete updated player list via a 'playerListUpdated' event to all clients in the room whenever the list changes.
-   - input / output: N/A
+- file name: src/stores/gameStore.ts
+  - classname: N/A (Zustand Hook/Store)
+  - function name: connect (action), onGameStateUpdated callback
+  - short description: (Issue #77) Updated the `onPlayerListUpdated` listener callback to correctly handle the `{ players: Player[] }` payload, convert it to a map for `currentRoom.players`, and update `currentPlayer`. Removed player-related update logic from the `onGameStateUpdated` callback to centralize updates.
+  - input / output: N/A
+
+- file name: src/pages/GamePage.tsx
+  - classname: N/A (Function Component)
+  - function name: GamePage (playersArray creation logic)
+  - short description: (Issue #77 Fix) Modified the logic for creating `playersArray` to generate the list from `currentRoom.players` even when `game.playersInfo` is not yet available (before game start), ensuring the player list is visible upon joining the room.
+  - input / output: N/A

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -139,7 +139,15 @@ io.on('connection', (socket: Socket) => {
           io.to(roomId).emit('playerListUpdated', { players: Array.from(room.players.values()) });
 
           // 参加したプレイヤーにルーム情報を送信
-          socket.emit('roomJoined', room);
+          // Map をプレーンオブジェクトに変換
+          const playersObject = Object.fromEntries(room.players.entries());
+          // 送信するルーム情報を作成 (元の room オブジェクトを変更しないようにコピー、gameManager は除外)
+          const roomToSend = {
+            ...room,
+            players: playersObject,
+            gameManager: undefined, // クライアントには不要なため除外
+          };
+          socket.emit('roomJoined', roomToSend); // 変換後のオブジェクトを送信
 
           // ゲームが進行中の場合、参加したプレイヤーに現在のゲーム状態を送信
           const gameState = room.gameManager.getGameState();

--- a/src/pages/GamePage.tsx
+++ b/src/pages/GamePage.tsx
@@ -318,20 +318,19 @@ const GamePage: FC = () => {
     // TODO: もっと良いローディング表示/エラー表示
     return <div className="p-4 text-center">ルーム情報を読み込み中...</div>;
   }
-  // playersInfo をオブジェクトから配列に変換 (game と playersInfo が存在する場合)
-  // Player オブジェクトの他の情報 (connected など) も必要なので、currentRoom.players とマージする
-  const playersArray = game?.playersInfo
-    ? Object.entries(game.playersInfo).map(([id, info]) => ({
-        id,
-        name: info.name,
-        // currentRoom.players から他の情報を取得 (存在しない場合のデフォルト値も考慮)
-        connected: currentRoom.players[id]?.connected ?? false,
-        isHost: currentRoom.players[id]?.isHost ?? false,
-        roomId: currentRoom.players[id]?.roomId ?? null,
-        score: game.playerStates?.[id]?.score ?? 0, // スコアは game.playerStates から取得
-        // lastConnected は表示には不要なため省略
+  // playersInfo をオブジェクトから配列に変換
+  // game.playersInfo がなくても currentRoom.players からリストを生成するように修正
+  const playersArray = currentRoom?.players
+    ? Object.values(currentRoom.players).map((player) => ({
+        id: player.id,
+        name: player.name, // currentRoom.players に name がある前提 (Player 型に含まれるはず)
+        connected: player.connected,
+        isHost: player.isHost,
+        roomId: player.roomId,
+        // スコアは game state があればそこから、なければ 0
+        score: game?.playerStates?.[player.id]?.score ?? 0,
       }))
-    : [];
+    : []; // currentRoom.players がなければ空配列
 
   // ボードのスケーリング計算 (SinglePlayerPageから移植・調整)
   const getBoardScale = () => {

--- a/src/services/socketService.ts
+++ b/src/services/socketService.ts
@@ -191,6 +191,11 @@ public leaveRoom(roomId: string): void {
     this.registerEventListener('roomListUpdated', callback);
   }
 
+  // Add listener for player list updates
+  public onPlayerListUpdated(callback: (payload: { players: Player[] }) => void): void { // Update callback type to match server payload
+    this.registerEventListener('playerListUpdated', callback as ServerToClientEvents['playerListUpdated']); // Cast for registerEventListener
+  }
+
   public onError(callback: ServerToClientEvents['error']): void {
     this.registerEventListener('error', callback);
   }

--- a/src/stores/gameStore.ts
+++ b/src/stores/gameStore.ts
@@ -88,12 +88,7 @@ const useGameStore = create<GameStore>((set, get) => ({
       });
 
       socketService.onRoomJoined((room) => {
-        // --- DEBUG ---
-        console.log('[DEBUG onRoomJoined] Received room object:', JSON.stringify(room, null, 2));
-        // --- END DEBUG ---
-
         // room オブジェクトと players プロパティが存在するかチェック
-        // room オブジェクトと players プロパティが存在するか、より詳細にチェック
         if (!room || typeof room !== 'object') {
           console.error('[GameStore] Received invalid room object in onRoomJoined:', room);
           return;
@@ -120,10 +115,6 @@ const useGameStore = create<GameStore>((set, get) => ({
           } else {
             // currentPlayer が null の場合、socketId を使って room.players から自分の情報を探す
             const socketId = get().socketId; // ストアから socketId を取得
-            // --- DEBUG ---
-            console.log(`[DEBUG onRoomJoined] Trying to find player for socketId: ${socketId}`);
-            console.log(`[DEBUG onRoomJoined] playersMap keys:`, Object.keys(playersMap));
-            // --- END DEBUG ---
             if (socketId && playersMap.hasOwnProperty(socketId)) {
               updatedPlayer = playersMap[socketId];
               console.log(`[GameStore onRoomJoined] Set currentPlayer based on socketId:`, updatedPlayer);
@@ -154,9 +145,6 @@ const useGameStore = create<GameStore>((set, get) => ({
 
       // Add listener for player list updates
       socketService.onPlayerListUpdated((payload) => { // 引数を payload に変更
-        // --- DEBUG LOGGING ---
-        // console.log('[DEBUG] Received payload in onPlayerListUpdated:', JSON.stringify(payload, null, 2)); // 必要なら復活
-        // --- END DEBUG LOGGING ---
         console.log('[GameStore] Received playerListUpdated event:', payload);
         set((state) => {
           if (!state.currentRoom) {
@@ -182,11 +170,6 @@ const useGameStore = create<GameStore>((set, get) => ({
               updatedPlayer = { ...state.currentPlayer, ...playersMap[currentId] };
             } else {
               // Key does not exist in the new map (player left?)
-              // --- DEBUG ---
-              console.log(`[DEBUG onPlayerListUpdated] Warning Triggered!`);
-              console.log(`[DEBUG onPlayerListUpdated] state.currentPlayer.id:`, state.currentPlayer?.id);
-              console.log(`[DEBUG onPlayerListUpdated] playersMap keys:`, Object.keys(playersMap));
-              // --- END DEBUG ---
               console.warn(`[GameStore] Current player ${currentId} not found in updated player list (playersMap keys: ${Object.keys(playersMap).join(', ')})`);
               // updatedPlayer は state.currentPlayer のまま (変更しない)
             }

--- a/src/types/socket.ts
+++ b/src/types/socket.ts
@@ -20,6 +20,7 @@ export interface ServerToClientEvents {
   solutionAttemptResult: (payload: { success: boolean; scores: Record<string, number>; nextPlayerId?: string }) => void; // 解法試行の結果 (スコア全体を返す)
   gameOver: (payload: { winner: Player | null; scores: Record<string, number> }) => void; // ゲーム終了と勝者、最終スコア
   // --- ここまで ---
+  playerListUpdated: (payload: { players: Player[] }) => void; // プレイヤーリスト全体の更新 (サーバー形式に合わせる)
 }
 
 export interface ClientToServerEvents {


### PR DESCRIPTION
Closes #77

サーバーから送信される `playerListUpdated` イベントを処理し、ゲーム開始前でもプレイヤーリストが正しく表示されるようにフロントエンドを修正しました。

- **`playerListUpdated` イベント処理:**
    - サーバーのペイロード形式 (`{ players: Player[] }`) に合わせて型定義とイベントリスナーを修正。
    - `gameStore` でイベントをリッスンし、`currentRoom.players` と `currentPlayer` を更新するように修正。プレイヤー情報の更新を `onPlayerListUpdated` に一本化。
- **プレイヤーリスト表示修正:**
    - `GamePage` で、ゲーム開始前 (`game.playersInfo` が存在しない場合) でも `currentRoom.players` を元にプレイヤーリストを表示するように修正。